### PR TITLE
Prevent glitching on heater

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,10 +49,17 @@ class PIDAutoTune(KettleController):
 			heat_percent = atune.output
 			heating_time = sampleTime * heat_percent / 100
 			wait_time = sampleTime - heating_time
-			self.heater_on()
-			self.sleep(heating_time)
-			self.heater_off()
-			self.sleep(wait_time)
+			if heating_time == sampleTime:
+				self.heater_on()
+				self.sleep(heating_time)
+			elif wait_time == sampleTime:
+				self.heater_off()
+				self.sleep(wait_time)
+			else:
+				self.heater_on()
+				self.sleep(heating_time)
+				self.heater_off()
+				self.sleep(wait_time)
 
 		self.autoOff()
 


### PR DESCRIPTION
Prevent glitching on heater by checking if heater should stay fully on
or fully off during cycle.

I noticed on my system that when the heater should stay fully on or fully off it would glitch momentarily each cycle. It is very visible in the user interface but can also be seen on the LED on the SSR for the heater.