### PR TITLE
Divide accumulated peak size with number of peaks used

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -244,7 +244,7 @@ class AutoTuner(object):
 				absMax = max(self._peaks[i], absMax)
 				absMin = min(self._peaks[i], absMin)
 
-			self._inducedAmplitude /= 6.0
+			self._inducedAmplitude /= len(self._peaks) - 2
 
 			# check convergence criterion for amplitude of induced oscillation
 			amplitudeDev = ((0.5 * (absMax - absMin) - self._inducedAmplitude)


### PR DESCRIPTION
In your code you divide the accumulated inducedAmplitude with the constant 6 instead of the number of amplitudes used. This will result in a wrong estimate of the induced amplitude unless the number of amplitudes is 6.