### PR TITLE
Improve min/max detection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -200,8 +200,8 @@ class AutoTuner(object):
 		isMin = True
 
 		for val in self._inputs:
-			isMax = isMax and (inputValue >= val)
-			isMin = isMin and (inputValue <= val)
+			isMax = isMax and (inputValue > val)
+			isMin = isMin and (inputValue < val)
 
 		self._inputs.append(inputValue)
 


### PR DESCRIPTION
min/max is detected by checking if current value is larger/smaller or equal than any previous seen value in the lookback window. This should be strictly larger or smaller. The equality makes the max/min detector overly eager to detect inflecions.

Runs of the same value that fill the lookback deque result in a detected
peak when using equality in the max/min checks. This happens frequently
on systems using ds18b20 temperature sensors.

Using a strict larger/smaller check also matches the original C code
https://github.com/br3ttb/Arduino-PID-AutoTune-Library/blob/master/PID_AutoTune_v0/PID_AutoTune_v0.cpp#L72

I've tested this on my system, had one other user test it, and tested it offline on 3 different datasets, all showing better max/min detection and being able to run with a 30 sec (default) lookback.